### PR TITLE
flake: add rev to `/etc/os-release`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           modules = [
             (import ./hosts/rowhammer/configuration.nix)
             agenix.nixosModules.default
+            (import ./hosts/common/build-info.nix { inherit self; })
           ];
         };
         vesuvius = nixpkgs.lib.nixosSystem {
@@ -35,6 +36,7 @@
           modules = [
             (import ./hosts/vesuvius/configuration.nix)
             agenix.nixosModules.default
+            (import ./hosts/common/build-info.nix { inherit self; })
           ];
         };
         zerocool = nixpkgs.lib.nixosSystem {
@@ -42,6 +44,7 @@
           modules = [
             (import ./hosts/zerocool/configuration.nix)
             agenix.nixosModules.default
+            (import ./hosts/common/build-info.nix { inherit self; })
           ];
         };
       };

--- a/hosts/common/build-info.nix
+++ b/hosts/common/build-info.nix
@@ -1,0 +1,5 @@
+{ self }:
+{ ... }:
+{
+    system.nixos.variantName = if (self ? rev) then self.rev else self.dirtyRev;
+}


### PR DESCRIPTION
`VARIANT` will be the git SHA thing, suffixed by `-dirty` if it's dirty. This lets us (non-securely) identify what a host is actually running and whether it was built from a dirty commit (bad). `VARIANT` is the easiest `os-release` variable to stuff crap into without redoing the whole file.

This actually uses a flake thing! Go flakes!

Tested on celestia https://github.com/mehbark/homelab/commit/3d8dfaad5a5031860ec7dcff4ab1fda69707d997